### PR TITLE
Fix type error for missing target

### DIFF
--- a/Classes/Overrides/PageRepository.php
+++ b/Classes/Overrides/PageRepository.php
@@ -102,7 +102,7 @@ class PageRepository extends \TYPO3\CMS\Frontend\Page\PageRepository
             $pageUid = $integration->resolvePageId($config->getId());
             $targetPage = BackendUtility::getRecord('pages', $pageUid);
 
-            $result = parent::checkValidShortcutOfPage($targetPage, $additionalWhereClause);
+            $result = parent::checkValidShortcutOfPage((array)$targetPage, $additionalWhereClause);
             if (empty($result)) {
                 return $result;
             }


### PR DESCRIPTION
The return value of BackendUtility::getRecord() can be array or null, but the first param for checkValidShortcutOfPage must be an array.

Currently this can break a complete page if the shortcut is part of the main menu:
Argument 1 passed to TYPO3\CMS\Frontend\Page\PageRepository::checkValidShortcutOfPage() must be of the type array, null given, called in /.../typo3conf/ext/custom_shortcut/Classes/Overrides/PageRepository.php on line 105

To prevent this error we just type cast it to array always. Tested with TYPO3 9.5.30 and custom_shortcuts 0.9.2