### PR TITLE
Overwrite the page uid field only for CE

### DIFF
--- a/Classes/Overrides/PageRepository10.php
+++ b/Classes/Overrides/PageRepository10.php
@@ -76,8 +76,12 @@ class PageRepository10 extends \TYPO3\CMS\Core\Domain\Repository\PageRepository
                 throw new \RuntimeException($message, 1294587212);
             }
         }
-
-        $page['uid'] = 'shortcut://'.$shortcutFieldValue;
+        
+        // Check if a CE anchor is set
+        if (str_contains($shortcutFieldValue,'tt_content')){
+            $page['uid'] .= '#' . preg_replace('/\D/', '', $shortcutFieldValue);
+        }
+        
         // Return resulting page:
         return $page;
     }


### PR DESCRIPTION
Add condition to check if a content element anchor is set.