### PR TITLE
[BUGFIX] Removed namespaces in ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,8 +1,5 @@
 <?php
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Page\PageRepositoryGetPageHookInterface;
-
 $GLOBALS['TYPO3_CONF_VARS']['EXT']['custom_shortcut']['shortcut'] = [
     'tt_content' => \HDNET\CustomShortcut\Shortcut\Content::class,
     'pages' => \HDNET\CustomShortcut\Shortcut\Page::class


### PR DESCRIPTION
Removed namespaces in ext_localconf.php to prevent errors in cached ext_localconf-files